### PR TITLE
pull before add file and commit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -74,6 +74,11 @@ class Bot(object):
 		# load repo
 		repo_dir = os.sep.join([root_dir, repo_name])
 		repo = Repo(repo_dir)
+		# always pull first
+		remote = repo.remote(remote_name)
+		remote.set_url('https://%s:%s@github.com/%s/%s.git' %\
+			(settings.USERNAME, settings.PASSWORD, settings.USERNAME, repo_name))
+		remote.pull()
 		# copy and add files specified to local repository
 		for file in file_list:
 			src = os.sep.join([settings.DEFAULT_SOURCE_ROOT_DIR, repo_name, file])

--- a/bot.py
+++ b/bot.py
@@ -96,10 +96,6 @@ class Bot(object):
 		# make commit
 		try:
 			repo.git.commit('-m %s' % message)
-			remote = repo.remote(remote_name)
-			remote.set_url('https://%s:%s@github.com/%s/%s.git' %\
-				(settings.USERNAME, settings.PASSWORD, settings.USERNAME, repo_name))
-			remote.pull()
 			remote.push()
 		except GitCommandError as e:
 			print(e)


### PR DESCRIPTION
Original code in addfiles_commit_push_remote() only do git pull after copying files and make commit.  
In my case when there is no more new files to be added, there will always to git commit exception before pulling.  
So even if I clean up repository manually, the bot still goes exception.

```python
def addfiles_commit_push_remote(self, repo_name, root_dir, file_list, message='', remote_name='origin'):
		# load repo
		repo_dir = os.sep.join([root_dir, repo_name])
		repo = Repo(repo_dir)
		# copy and add files specified to local repository
		for file in file_list:
			src = os.sep.join([settings.DEFAULT_SOURCE_ROOT_DIR, repo_name, file])
			dest = os.sep.join([repo_dir, file])
			try:
				shutil.copy2(src, dest)
				repo.git.add(file)
			except IOError as e: # parent directory not exists or something wrong
				# creating parent directories
				os.makedirs(os.path.dirname(dest))
				shutil.copy2(src, dest)
				repo.git.add(file)
		# make commit
		try:
			repo.git.commit('-m %s' % message)
			remote = repo.remote(remote_name)
			remote.set_url('https://%s:%s@github.com/%s/%s.git' %\
				(settings.USERNAME, settings.PASSWORD, settings.USERNAME, repo_name))
			remote.pull()
			remote.push()
		except GitCommandError as e:
			print(e)
			raise BranchUpToDateException
```

Solved by always pull before adding files.